### PR TITLE
Add Kitchen testsupport to magento cookbook

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -24,3 +24,6 @@ suites:
         server_debian_password: test
         server_root_password: test
         server_repl_password: test
+      magento:
+        db:
+          password: magento

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -7,10 +7,20 @@ provisioner:
 
 platforms:
   - name: ubuntu-12.04
+    driver_config:
+      network:
+      - ["forwarded_port", {guest: 80, host: 8080, guest: 443, host: 8443}]
   - name: centos-6.4
+    driver_config:
+        network:
+        - ["forwarded_port", {guest: 80, host: 8081, guest: 443, host: 8444}]
 
 suites:
   - name: default
     run_list:
       - recipe[magento::default]
     attributes:
+      mysql:
+        server_debian_password: test
+        server_root_password: test
+        server_repl_password: test

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,16 @@
+---
+driver:
+  name: vagrant
+
+provisioner:
+  name: chef_solo
+
+platforms:
+  - name: ubuntu-12.04
+  - name: centos-6.4
+
+suites:
+  - name: default
+    run_list:
+      - recipe[magento::default]
+    attributes:

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source 'https://rubygems.org'
 
 gem 'berkshelf'
+gem 'test-kitchen'
+gem 'kitchen-vagrant'


### PR DESCRIPTION
adds simple kitchen testsupport to magento cookbook
- installs `magento::default` into a virtualbox
- sets forwarding network ports `80` and `443` to `808x` and `844x`` on host machine
- sets mysql passwortds to `test`

Update:
- sets `set_unless[:magento][:db][:password] = "magento"` in kitchen.yml 
