### PR TITLE
Add ability to adjust several nginx timeouts

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,6 +24,8 @@ end
 
 # Web Server
 default[:magento][:webserver] = 'nginx'
+default[:magento][:nginx][:send_timeout] = 60
+default[:magento][:nginx][:proxy_read_timeout] = 60
 
 default['php-fpm']['pools'] = [
   {

--- a/templates/default/nginx-site.erb
+++ b/templates/default/nginx-site.erb
@@ -19,6 +19,10 @@ server {
   root <%= @path %>;
   autoindex off;
 
+  # Higher timeouts for when we need to reindex caches in the gui
+  send_timeout <%= node[:magento][:nginx][:send_timeout] %>;
+  proxy_read_timeout <%= node[:magento][:nginx][:proxy_read_timeout] %>;
+
   # protection (we have no .htaccess)
   location ~ (^/(app/|includes/|lib/|/pkginfo/|var/|report/config.xml)|/\.git/|/\.hg/|/\.svn/|/.hta.+) {
     deny all;


### PR DESCRIPTION
This gives the ability for a user to specify different timeouts for `send_timeout` and `proxy_read_timeout`.  This is useful for situations where memcached or redis is involved and the cache needs to be manually rebuilt.  The attribute values set are the default nginx values.
