### PR TITLE
Moving http/https port to attribute

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -25,6 +25,8 @@ end
 
 # Web Server
 default[:magento][:webserver] = 'nginx'
+default[:magento][:http_port] = 80
+default[:magento][:https_port] = 443
 default[:magento][:nginx][:send_timeout] = 60
 default[:magento][:nginx][:proxy_read_timeout] = 60
 

--- a/templates/default/apache2-site.conf.erb
+++ b/templates/default/apache2-site.conf.erb
@@ -1,11 +1,11 @@
 <%- if @params[:ssl] %>
-<VirtualHost *:443>
+<VirtualHost *:<%= node[:magento][:https_port] %>
 
   SSLEngine on
   SSLCertificateFile <%= @params[:ssl_cert] %>
   SSLCertificateKeyFile <%= @params[:ssl_key] %>
 <%- else %>
-<VirtualHost *:80>
+<VirtualHost *:<%= node[:magento][:http_port] %>>
 <%- end %>
 
   ServerName <%= node[:magento][:domain] %>

--- a/templates/default/nginx-site.erb
+++ b/templates/default/nginx-site.erb
@@ -5,13 +5,13 @@ map $http_host $magesite {
 
 server {
 <% if @ssl %>
-  listen 443;
+  listen <%= node[:magento][:https_port] %>;
   ssl on;
   ssl_certificate <%= @ssl_cert %>;
   ssl_certificate_key <%= @ssl_key %>;
   access_log  <%= node[:nginx][:log_dir] %>/magento-ssl.access.log;
 <% else %>
-  listen 80;
+  listen <%= node[:magento][:http_port] %>;
   access_log  <%= node[:nginx][:log_dir] %>/magento.access.log;
 <% end %>
 


### PR DESCRIPTION
This is to make wrapping the cookbook a little easier (i.e. someone wants to run varnish or another caching service on 80).
