### PR TITLE
Update dependencies to compatible versions

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -12,10 +12,12 @@ recipe 'magento', 'Prepares app stack for magento deployments'
   supports os
 end
 
-%w(apt yum apache2 nginx mysql openssl php yum-epel
-   mysql-chef_gem).each do |cb|
+depends 'mysql', '< 6.0.0'
+depends 'mysql-chef_gem', '< 1.0.0'
+
+%w(apt yum apache2 nginx openssl php yum-epel).each do |cb|
   depends cb
 end
 
-depends 'php-fpm', '>= 0.6.4'
+depends 'php-fpm', '<= 0.7.0'
 depends 'nginx', '~> 2.6'


### PR DESCRIPTION
I got some chef errors during vagrant up/provision. It seems ther have been some updates to the latest versions of mysql and php-fpm cookbooks which are incompatible with this cook book.

I updated the dependency versions for this cook book to use the older versions of mysql and pnp-fpm to make it work.
